### PR TITLE
feat: add `derive` feature flag for Cargo.toml-syntax-compatibility with `serde`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members  = ["serdev", "serdev_derive"]
 exclude  = ["examples"]
 
 [workspace.package]
-version    = "0.3.1"
+version    = "0.3.2"
 edition    = "2024"
 authors    = ["kanarus <mail@kanarus.dev>"]
 homepage   = "https://crates.io/crates/serdev"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,8 +9,8 @@ tasks:
       - if [ -d ./target ]; then  find  -regex ".*target\|.*Cargo.lock" -exec rm -rf {} +; fi # clean cache for correctness
     cmds:
       - echo "CLEANUP CHECK" && ls -al
-      - task: __ci__
-  __ci__:
+      - task: ci
+  ci:
     deps:
       - test
       - check
@@ -46,11 +46,12 @@ tasks:
   test:doc:
     dir: ./serdev
     cmds:
-      - cargo test --doc
+      - cargo test --doc --all-features
   
   test:lib:
     cmds:
-      - cargo test --lib
+      - cargo test --lib --no-default-features
+      - cargo test --lib --features derive,
 
   test:examples:
     dir: examples
@@ -74,7 +75,8 @@ tasks:
             echo "--lib --tests --examples"
           fi          
     cmds:
-      - cargo clippy {{.targets}} -- --deny warnings
+      - cargo clippy {{.targets}} --no-default-features -- --deny warnings
+      - cargo clippy {{.targets}} --features derive, -- --deny warnings
       - cd examples && cargo clippy --examples -- --deny warnings
   
   ##### bench #####

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,6 +9,6 @@ version = "0.0.0"
 edition = "2024"
 
 [dev-dependencies]
-serdev     = { path = "../serdev" }
+serdev     = { path = "../serdev", features = ["derive"] }
 serde_json = { version = "1.0" }
 validator  = { version = "0.20", features = ["derive"] }

--- a/examples/reexport/reexporter/Cargo.toml
+++ b/examples/reexport/reexporter/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-serdev = { path = "../../../serdev" }
+serdev = { path = "../../../serdev", features = ["derive"] }

--- a/serdev/Cargo.toml
+++ b/serdev/Cargo.toml
@@ -12,9 +12,13 @@ keywords      = { workspace = true }
 categories    = { workspace = true }
 license       = { workspace = true }
 
+[features]
+default = ["derive"] # in most cases, there's no reason to use serdev, instead of serde, without derive...
+derive  = ["dep:serdev_derive", "serde/derive"]
+
 [dependencies]
-serdev_derive = { version = "=0.3.1", path = "../serdev_derive" }
-serde         = { version = "1", features = ["derive"] }
+serdev_derive = { version = "=0.3.2", path = "../serdev_derive", optional = true }
+serde         = { version = "1" }
 
 [dev-dependencies]
 serde_json = "1.0" # for README doc test

--- a/serdev/src/lib.rs
+++ b/serdev/src/lib.rs
@@ -1,9 +1,12 @@
 #![cfg_attr(all(doc, not(docsrs)), doc = include_str!("../../README.md"))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use ::serde::de::{self, Deserialize, Deserializer};
 pub use ::serde::ser::{self, Serialize, Serializer};
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
 pub use serdev_derive::{Deserialize, Serialize};
-
+#[cfg(feature = "derive")]
 #[doc(hidden)]
 pub mod __private__ {
     pub use ::serde;


### PR DESCRIPTION
- close #33 

edit: serdev's `derive` feature is introduced as a default feature and doesn't break the backward-compatibility with 0.3.* 